### PR TITLE
Fix issue #2 by replacing switch sorting with dictionary

### DIFF
--- a/DataBase/Controllers/AccountController.cs
+++ b/DataBase/Controllers/AccountController.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 using DataBase.Services;
 using DataBase.Models;
+using DataBase.Extensions;
 
 namespace DataBase.Controllers
 {
@@ -41,8 +42,7 @@ namespace DataBase.Controllers
 
             if (!(employee != null && PasswordHashService.VerifyPassword(model.Password, employee.PasswordHash)))
             {
-                ModelState.AddModelError("", "Пошта або пароль неправильні!"); 
-                return View(model);
+                return this.ViewWithModelError("Пошта або пароль неправильні!", model);
             }
             var claims = new List<Claim>
         {

--- a/DataBase/Controllers/ReservationCustomerController.cs
+++ b/DataBase/Controllers/ReservationCustomerController.cs
@@ -2,6 +2,7 @@
 using DataBase.Models;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
+using DataBase.Extensions;
 
 namespace DataBase.Controllers
 {
@@ -25,8 +26,7 @@ namespace DataBase.Controllers
             var customer = _context.Customers.FirstOrDefault(c => c.PassportNumber == passportNumber);
             if (customer == null)
             {
-                TempData["ErrorMessage"] = $"Клієнта з номером паспорта {passportNumber} не знайдено.";
-                return RedirectToAction("Search");
+                return this.RedirectWithTempError($"Клієнта з номером паспорта {passportNumber} не знайдено.", "Search");
             }
 
             var reservations = _context.Reservation
@@ -52,8 +52,7 @@ namespace DataBase.Controllers
 
             if (reservation == null)
             {
-                TempData["ErrorMessage"] = "Резервацію не знайдено.";
-                return RedirectToAction("Search");
+                return this.RedirectWithTempError("Резервацію не знайдено.", "Search");
             }
 
             var services = _context.ServiceUsage

--- a/DataBase/Controllers/ReservationsController.cs
+++ b/DataBase/Controllers/ReservationsController.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using DataBase.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.EntityFrameworkCore;
-using DataBase.Models;
 using Microsoft.Data.SqlClient;
-using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
 
 namespace DataBase.Controllers
 {
@@ -81,8 +77,7 @@ namespace DataBase.Controllers
 
         public IActionResult Create()
         {
-            ViewData["CustomerId"] = new SelectList(_context.Customers, "CustomerId", "FullName");
-            ViewData["RoomId"] = new SelectList(_context.Rooms.Include(room => room.RoomType), "RoomId", "TypeAndNumber");
+            SetCustomerRoomViewData();
             return View();
         }
 
@@ -92,8 +87,6 @@ namespace DataBase.Controllers
         {
             try
             {
-
-
                 if (reservation.CheckInDate >= reservation.CheckOutDate)
                 {
                     ModelState.AddModelError("", "Check-out date must be after check-in date.");
@@ -124,9 +117,7 @@ namespace DataBase.Controllers
             {
                 ModelState.AddModelError("", ex.ToString());
             }
-            ViewData["CustomerId"] = new SelectList(_context.Customers, "CustomerId", "FullName", reservation.CustomerId);
-            ViewData["RoomId"] = new SelectList(_context.Rooms.Include(room => room.RoomType), "RoomId", "TypeAndNumber", reservation.RoomId);
-
+            SetCustomerRoomViewData(reservation);
             return View(reservation);
         }
 
@@ -142,8 +133,7 @@ namespace DataBase.Controllers
             {
                 return NotFound();
             }
-            ViewData["CustomerId"] = new SelectList(_context.Customers, "CustomerId", "FullName", reservation.CustomerId);
-            ViewData["RoomId"] = new SelectList(_context.Rooms.Include(room => room.RoomType), "RoomId", "TypeAndNumber", reservation.RoomId);
+            SetCustomerRoomViewData(reservation);
             return View(reservation);
         }
 
@@ -194,8 +184,7 @@ namespace DataBase.Controllers
                 return RedirectToAction(nameof(Index));
             }
 
-            ViewData["CustomerId"] = new SelectList(_context.Customers, "CustomerId", "FullName", reservation.CustomerId);
-            ViewData["RoomId"] = new SelectList(_context.Rooms.Include(room => room.RoomType), "RoomId", "TypeAndNumber", reservation.RoomId);
+            SetCustomerRoomViewData(reservation);
             return View(reservation);
         }
 
@@ -236,5 +225,10 @@ namespace DataBase.Controllers
             return _context.Reservation.Any(e => e.ReservationId == id);
         }
 
+        private void SetCustomerRoomViewData(Reservation? reservation = null)
+        {
+            ViewData["CustomerId"] = new SelectList(_context.Customers, "CustomerId", "FullName", reservation?.CustomerId);
+            ViewData["RoomId"] = new SelectList(_context.Rooms.Include(room => room.RoomType), "RoomId", "TypeAndNumber", reservation?.RoomId);
+        }
     }
 }

--- a/DataBase/Controllers/RoomsController.cs
+++ b/DataBase/Controllers/RoomsController.cs
@@ -81,7 +81,7 @@ namespace DataBase.Controllers
 
         public IActionResult Create()
         {
-            ViewData["RoomTypeId"] = new SelectList(_context.RoomTypes, "TypeId", "TypeName");
+            SetRoomTypeViewData();
             return View();
         }
 
@@ -96,7 +96,7 @@ namespace DataBase.Controllers
 
                 return RedirectToAction(nameof(Index));
             }
-            ViewData["RoomTypeId"] = new SelectList(_context.RoomTypes, "TypeId", "TypeName", room.RoomTypeId);
+            SetRoomTypeViewData(room.RoomTypeId);
             return View(room);
         }
 
@@ -112,7 +112,7 @@ namespace DataBase.Controllers
             {
                 return NotFound();
             }
-            ViewData["RoomTypeId"] = new SelectList(_context.RoomTypes, "TypeId", "TypeName", room.RoomTypeId);
+            SetRoomTypeViewData(room.RoomTypeId);
             return View(room);
         }
 
@@ -146,7 +146,7 @@ namespace DataBase.Controllers
                 }
                 return RedirectToAction(nameof(Index));
             }
-            ViewData["RoomTypeId"] = new SelectList(_context.RoomTypes, "TypeId", "TypeName", room.RoomTypeId);
+            SetRoomTypeViewData(room.RoomTypeId);
             return View(room);
         }
 
@@ -169,8 +169,6 @@ namespace DataBase.Controllers
             return View(room);
         }
 
-
-
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
@@ -190,6 +188,10 @@ namespace DataBase.Controllers
         private bool RoomExists(int id)
         {
             return _context.Rooms.Any(e => e.RoomId == id);
+        }
+        private void SetRoomTypeViewData(int? roomTypeId = null)
+        {
+            ViewData["RoomTypeId"] = new SelectList(_context.RoomTypes, "TypeId", "TypeName", roomTypeId);
         }
     }
 }

--- a/DataBase/Controllers/ServiceUsagesController.cs
+++ b/DataBase/Controllers/ServiceUsagesController.cs
@@ -82,17 +82,7 @@ namespace DataBase.Controllers
         }
         public IActionResult Create()
         {
-            ViewData["ReservationId"] = new SelectList(
-     _context.Reservation
-         .Include(r => r.Customer)
-         .Include(r => r.Room)
-         .ToList(),
-     "ReservationId",
-     "DisplayText"
- );
-
-            ViewData["EmployeeId"] = new SelectList(_context.Employees, "EmployeesId", "NameWithPosition");
-            ViewData["ServicesId"] = new SelectList(_context.Services, "ServicesId", "ServicesName");
+            SetServiceUsageViewData();
             return View();
         }
 
@@ -106,17 +96,7 @@ namespace DataBase.Controllers
                 await _context.SaveChangesAsync();
                 return RedirectToAction(nameof(Index));
             }
-            ViewData["ReservationId"] = new SelectList(
-     _context.Reservation
-         .Include(r => r.Customer)
-         .Include(r => r.Room)
-         .ToList(),
-     "ReservationId",
-     "DisplayText",
-     serviceUsage.ReservationId
- );
-            ViewData["EmployeeId"] = new SelectList(_context.Employees, "EmployeesId", "NameWithPosition", serviceUsage.EmployeeId);
-            ViewData["ServicesId"] = new SelectList(_context.Services, "ServicesId", "ServicesName", serviceUsage.ServicesId);
+            SetServiceUsageViewData(serviceUsage);
             return View(serviceUsage);
         }
         public async Task<IActionResult> Edit(int? id)
@@ -131,17 +111,8 @@ namespace DataBase.Controllers
             {
                 return NotFound();
             }
-            ViewData["ReservationId"] = new SelectList(
-     _context.Reservation
-         .Include(r => r.Customer)
-         .Include(r => r.Room)
-         .ToList(),
-     "ReservationId",
-     "DisplayText",
-     serviceUsage.ReservationId
- );
-            ViewData["EmployeeId"] = new SelectList(_context.Employees, "EmployeesId", "NameWithPosition", serviceUsage.EmployeeId);
-            ViewData["ServicesId"] = new SelectList(_context.Services, "ServicesId", "ServicesName", serviceUsage.ServicesId);
+
+            SetServiceUsageViewData(serviceUsage);
             return View(serviceUsage);
         }
 
@@ -174,17 +145,7 @@ namespace DataBase.Controllers
                 }
                 return RedirectToAction(nameof(Index));
             }
-            ViewData["ReservationId"] = new SelectList(
-    _context.Reservation
-        .Include(r => r.Customer)
-        .Include(r => r.Room)
-        .ToList(),
-    "ReservationId",
-    "DisplayText",
-    serviceUsage.ReservationId
-);
-            ViewData["EmployeeId"] = new SelectList(_context.Employees, "EmployeesId", "NameWithPosition", serviceUsage.EmployeeId);
-            ViewData["ServicesId"] = new SelectList(_context.Services, "ServicesId", "ServicesName", serviceUsage.ServicesId);
+            SetServiceUsageViewData(serviceUsage);
             return View(serviceUsage);
         }
         public async Task<IActionResult> Delete(int? id)
@@ -227,6 +188,21 @@ namespace DataBase.Controllers
         private bool ServiceUsageExists(int id)
         {
             return _context.ServiceUsage.Any(e => e.UsageId == id);
+        }
+
+        private void SetServiceUsageViewData(ServiceUsage? serviceUsage = null)
+        {
+            ViewData["ReservationId"] = new SelectList(
+                _context.Reservation
+                    .Include(r => r.Customer)
+                    .Include(r => r.Room)
+                    .ToList(),
+                "ReservationId",
+                "DisplayText",
+                serviceUsage?.ReservationId
+            );
+            ViewData["EmployeeId"] = new SelectList(_context.Employees, "EmployeesId", "NameWithPosition", serviceUsage?.EmployeeId);
+            ViewData["ServicesId"] = new SelectList(_context.Services, "ServicesId", "ServicesName", serviceUsage?.ServicesId);
         }
     }
 }

--- a/DataBase/Extensions/ControllerRedirectsExtensions.cs
+++ b/DataBase/Extensions/ControllerRedirectsExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace DataBase.Extensions
+{
+    public static class ControllerRedirectsExtensions
+    {
+        public static IActionResult RedirectWithTempError(this Controller controller, string errorMessage, string redirectTo, object? routeValues = null)
+        {
+            controller.TempData["Error"] = errorMessage;
+            return controller.RedirectToAction(redirectTo, routeValues);
+        }
+        public static IActionResult ViewWithModelError(this Controller controller, string errorMessage, string viewName, object? routeValues = null)
+        {
+            controller.ModelState.AddModelError("", errorMessage);
+            return controller.View(viewName, routeValues);
+        }
+        public static IActionResult ViewWithModelError(this Controller controller, string errorMessage, object model, object? routeValues = null)
+        {
+            controller.ModelState.AddModelError("", errorMessage);
+            return controller.View(model);
+        }
+    }
+}

--- a/DataBase/Extensions/SortingDictionary.cs
+++ b/DataBase/Extensions/SortingDictionary.cs
@@ -1,0 +1,19 @@
+﻿namespace DataBase.Extensions
+{
+    public class SortingDictionary<T> : Dictionary<string, Func<IQueryable<T>, IQueryable<T>>>
+    {
+        private Func<IQueryable<T>, IQueryable<T>>? _defaultSort;
+
+        public void SetDefaultSort(Func<IQueryable<T>, IQueryable<T>> defaultSort)
+        {
+            _defaultSort = defaultSort;
+        }
+
+        public IQueryable<T> ApplySorting(IQueryable<T> query, string sortOrder)
+        {
+            return TryGetValue(sortOrder ?? string.Empty, out var sortFunc)
+                ? sortFunc(query)
+                : _defaultSort?.Invoke(query) ?? query;
+        }
+    }
+}

--- a/DataBase/appsettings.json
+++ b/DataBase/appsettings.json
@@ -1,7 +1,7 @@
 {
 
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=HotelDataBase2;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=HotelDataBase;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
 
   "Logging": {

--- a/DataBase/appsettings.json
+++ b/DataBase/appsettings.json
@@ -1,7 +1,7 @@
 {
 
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=HotelDataBase;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=HotelDataBase2;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
 
   "Logging": {


### PR DESCRIPTION
Closes #11 
Replaced `switch` statements for sorting with a **dictionary-based** approach that maps sorting keys to corresponding sorting functions. Introduced a custom `SortingDictionary<T>` to encapsulate sorting logic in a reusable manner. 
This refactoring improves maintainability, scalability, and simplifies future modifications or extensions.